### PR TITLE
Remove unused import causing Pandas error

### DIFF
--- a/org.knime.dl.python/py/DLPythonNetwork.py
+++ b/org.knime.dl.python/py/DLPythonNetwork.py
@@ -50,9 +50,6 @@
 
 import abc
 
-from pandas.util.testing import network
-
-
 _networks = {}
 
 _network_id_suffix = 0


### PR DESCRIPTION
Errors out in: pandas.util.testing import network

checking the pandas source code shows that the network method is not available.

```bash
Execute failed: An error occurred while creating the Keras network from its layer specifications. Details: No module named 'pandas.util.testing' Traceback (most recent call last): File "<string>", line 2, in <module> File "/opt/knime_5.4.0.linux.gtk.x86_64/knime_5.4.0/plugins/org.knime.dl.python_5.4.0.v202407310837/py/DLPythonNetwork.py", line 53, in <module> from pandas.util.testing import network ModuleNotFoundError: No module named 'pandas.util.testing'
```

Checking the code shows that its not used in file. There is a variable name so this must have been accidentally resolved by "intellisense"